### PR TITLE
ci: Add static code analysis of PRs

### DIFF
--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -24,4 +24,4 @@ jobs:
           args:  -E gosec -E bodyclose -E cyclop -E exhaustive -E godox
 
           # PR config -> only flag issues in changeset
-          only-new-issues: true
+          only-new-issues: false

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -1,0 +1,27 @@
+name: Run Static Code Analysis
+
+# This workflow uses golangci-lint to run static code analysis on PRs
+# In addition to default golanci-linters checks vulnerability checks (gosec), 
+# closing of openend http bodies (bodyclose), cyclomatic complexity (cyclop), 
+# exhaustive switches (exhaustive) and open TODO/FIXME comments (godox)
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.39
+
+          # Addtional Linters
+          args:  -E gosec -E bodyclose -E cyclop -E exhaustive -E godox
+
+          # PR config -> only flag issues in changeset
+          only-new-issues: true


### PR DESCRIPTION
Add a PR action using the
[golangci-lint](https://github.com/golangci/golangci-lint) meta
linter/linter aggregator to do analysis of the changeset.

Uses golangci-lint [Default
Linters](https://golangci-lint.run/usage/linters/#enabled-by-default-linters)

And the following optional linters:
* [bodyclose](https://github.com/timakin/bodyclose)
  * checking http response.Body is closed
* [cyclop](https://github.com/bkielbasa/cyclop)
  * checking function & pkg cyclomatic complexity
* [exhaustive](https://github.com/nishanths/exhaustive)
  * checking if enum switches are exhaustive
* [godox](https://github.com/matoous/godox)
  * checking for TODO, FIXME, etc comments
* [gosec](https://github.com/securego/gosec)
  * checking for security vulnerabilities